### PR TITLE
Update ova-compose.py

### DIFF
--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Copyright (c) 2023 VMware, Inc.  All Rights Reserved.
 #


### PR DESCRIPTION
Change shebang as it causes trouble when packaging the software as RPM.

Example of RPM linting:
[    4s] open-vmdk.x86_64: E: env-script-interpreter (Badness: 9) /usr/bin/ova-compose /usr/bin/env python3
[    4s] This script uses 'env' as an interpreter. For the rpm runtime dependency
[    4s] detection to work, the shebang #!/usr/bin/env <interpreter>  needs to be
[    4s] patched into #!/usr/bin/<interpreter>  otherwise the package dependency
[    4s] generator merely adds a dependency on /usr/bin/env rather than the actual
[    4s] interpreter /usr/bin/<interpreter>.  Alternatively, if the file should not be
[    4s] executed, then ensure that it is not marked as executable or don't install it
[    4s] in a path that is reserved for executables.